### PR TITLE
RPS-50: Fix failing integration tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ffc-rps-experiment-api",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Backend for future RPS experiments",
   "homepage": "https://github.com/DEFRA/ffc-rps-experiment-api",
   "main": "app/index.js",

--- a/test/integration/narrow/routes/action.test.js
+++ b/test/integration/narrow/routes/action.test.js
@@ -5,7 +5,11 @@ describe('available area calculation test', () => {
     await server.start()
   })
 
-  test('GET /action route should return 400 when parcel-id query parameter is missing', async () => {
+  afterEach(async () => {
+    await server.stop()
+  })
+
+  test('GET /action route should return 200 when parcel-id query parameter is provided', async () => {
     const request = {
       method: 'GET',
       url: '/action'
@@ -14,7 +18,7 @@ describe('available area calculation test', () => {
     expect(response.statusCode).toBe(400)
   })
 
-  test('GET /action route should return 200 when parcel-id query parameter is provided', async () => {
+  test('GET /action route should return 400 when parcel-id query parameter is missing', async () => {
     const request = {
       method: 'GET',
       url: '/action?parcel-id=123'

--- a/test/integration/narrow/routes/available-area.test.js
+++ b/test/integration/narrow/routes/available-area.test.js
@@ -5,6 +5,10 @@ describe('available area calculation test', () => {
     await server.start()
   })
 
+  afterEach(async () => {
+    await server.stop()
+  })
+
   test('POST /available-area route should return 200 when all parameters are valid', async () => {
     const request = {
       method: 'POST',

--- a/test/integration/narrow/routes/eligibility.test.js
+++ b/test/integration/narrow/routes/eligibility.test.js
@@ -5,6 +5,10 @@ describe('eligibility test', () => {
     await server.start()
   })
 
+  afterEach(async () => {
+    await server.stop()
+  })
+
   test('POST /eligibility route returns 200', async () => {
     const options = {
       method: 'POST',

--- a/test/integration/narrow/routes/healthy.test.js
+++ b/test/integration/narrow/routes/healthy.test.js
@@ -17,5 +17,5 @@ describe('Healthy test', () => {
 
     const response = await server.inject(options)
     expect(response.statusCode).toBe(200)
-  })  
+  })
 })

--- a/test/integration/narrow/routes/healthy.test.js
+++ b/test/integration/narrow/routes/healthy.test.js
@@ -5,6 +5,10 @@ describe('Healthy test', () => {
     await server.start()
   })
 
+  afterEach(async () => {
+    await server.stop()
+  })
+
   test('GET /healthy route returns 200', async () => {
     const options = {
       method: 'GET',
@@ -13,9 +17,5 @@ describe('Healthy test', () => {
 
     const response = await server.inject(options)
     expect(response.statusCode).toBe(200)
-  })
-
-  afterEach(async () => {
-    await server.stop()
-  })
+  })  
 })

--- a/test/integration/narrow/routes/healthz.test.js
+++ b/test/integration/narrow/routes/healthz.test.js
@@ -5,6 +5,10 @@ describe('Healthz test', () => {
     await server.start()
   })
 
+  afterEach(async () => {
+    await server.stop()
+  })
+
   test('GET /healthz route returns 200', async () => {
     const options = {
       method: 'GET',
@@ -13,9 +17,5 @@ describe('Healthz test', () => {
 
     const response = await server.inject(options)
     expect(response.statusCode).toBe(200)
-  })
-
-  afterEach(async () => {
-    await server.stop()
   })
 })

--- a/test/integration/narrow/routes/land-parcel.test.js
+++ b/test/integration/narrow/routes/land-parcel.test.js
@@ -5,6 +5,10 @@ describe('Land parcel test', () => {
     await server.start()
   })
 
+  afterEach(async () => {
+    await server.stop()
+  })
+
   test('GET /land-parcel should return 200 when a valid SBI is provided', async () => {
     const request = {
       method: 'GET',
@@ -35,9 +39,5 @@ describe('Land parcel test', () => {
 
     const response = await server.inject(request)
     expect(response.statusCode).toBe(400)
-  })
-
-  afterEach(async () => {
-    await server.stop()
-  })
+  })  
 })

--- a/test/integration/narrow/routes/land-parcel.test.js
+++ b/test/integration/narrow/routes/land-parcel.test.js
@@ -39,5 +39,5 @@ describe('Land parcel test', () => {
 
     const response = await server.inject(request)
     expect(response.statusCode).toBe(400)
-  })  
+  })
 })

--- a/test/unit/land-parcel/index.test.js
+++ b/test/unit/land-parcel/index.test.js
@@ -1,0 +1,12 @@
+const { getLandParcels } = require('../../../app/land-parcel')
+
+describe('get land parcels by SBI', () => {
+  test('should return an empty array when an unknown SBI is provided', () => {
+    const landParcels = getLandParcels(1234)
+    expect(landParcels.length).toEqual(0)
+  })
+  test('should return the land parcels when a known SBI is provided', () => {
+    const landParcels = getLandParcels(200599768)
+    expect(landParcels.length).toEqual(13)
+  })
+})


### PR DESCRIPTION
The jenkins pipeline failed due to the port being in use from a previous test execution.
Explicit start and stop commands have been added to each integration test.